### PR TITLE
🐛 remove empty chars (tabs, spaces and newlines) from amount value string

### DIFF
--- a/Classes/Transactions/Send/Preview/Main/Screens/SendTransaction/SendTransactionScreen.swift
+++ b/Classes/Transactions/Send/Preview/Main/Screens/SendTransaction/SendTransactionScreen.swift
@@ -177,7 +177,7 @@ extension SendTransactionScreen {
 
 extension SendTransactionScreen {
     private func bindAmount() {
-        let amountValue = self.amount
+        let amountValue = self.amount.replacingOccurrences(of: "\\s", with: "", options: .regularExpression)
         var showingValue = ""
 
         valueLabel.customizeAppearance(theme.valueLabelStyle)


### PR DESCRIPTION
**Problem (seen if the device has Locale Brazil):**

![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-13 at 11 18 10](https://github.com/user-attachments/assets/50eeffac-e212-4a0c-8e86-e15eb04ecd3c)