### PR TITLE
:lipstick: hide account secondary label in undo rekey screen for auth account item

### DIFF
--- a/Classes/Shared/Preview/AccountListItem/ViewModels/AccountListItemViewModel.swift
+++ b/Classes/Shared/Preview/AccountListItem/ViewModels/AccountListItemViewModel.swift
@@ -29,7 +29,7 @@ struct AccountListItemViewModel:
 
     private(set) var icon: ImageSource?
     private(set) var iconBottomRightBadge: Image?
-    private(set) var title: AccountPreviewTitleViewModel?
+    public var title: AccountPreviewTitleViewModel?
     private(set) var primaryAccessory: EditText?
     private(set) var secondaryAccessory: EditText?
     private(set) var accessoryIcon: UIImage?

--- a/Classes/ViewControllers/Ledger/Rekey/Shared/Views/RekeyInfo/UndoRekeyInfoViewModel.swift
+++ b/Classes/ViewControllers/Ledger/Rekey/Shared/Views/RekeyInfo/UndoRekeyInfoViewModel.swift
@@ -47,6 +47,9 @@ extension UndoRekeyInfoViewModel {
     private mutating func bindAuthAccountItem(_ authAccount: Account) {
         var viewModel = AccountListItemViewModel(authAccount)
         viewModel.bindIcon(authAccount.underlyingTypeImage)
+        if authAccount.name == authAccount.address.shortAddressDisplay {
+            viewModel.title = AccountPreviewTitleViewModel(primaryTitle: viewModel.title?.primaryTitle?.string, secondaryTitle: nil)
+        }
         authAccountItem = viewModel
     }
 }


### PR DESCRIPTION
The goal is to hide the "Rekeyed Account" label in the bottom cell of the Undo Rekey Screen.

**Before:**
![422014049-71647b08-cda9-43e7-98e2-d5adddb11599](https://github.com/user-attachments/assets/3d0bdf8b-45fd-44e4-befc-7f2a2b1dca5e)

**After:**
![422013864-acbeea86-339e-4e74-b6ad-888b4271e000](https://github.com/user-attachments/assets/de235dc0-aae0-4b6e-81bf-be4d39e16688)
