### PR TITLE
HD Wallets - QA Finding 6 - Backing up the Root Account should also back up the accounts attached to it

### DIFF
--- a/Classes/Shared/Tutorial/Screens/TutorialViewController.swift
+++ b/Classes/Shared/Tutorial/Screens/TutorialViewController.swift
@@ -381,6 +381,13 @@ extension TutorialViewController {
             localAccount.isBackedUp = true
             session?.authenticatedUser?.updateAccount(localAccount)
         }
+        
+        if let walletId = account.hdWalletAddressDetail?.walletId {
+            session?.authenticatedUser?.accounts(withWalletId: walletId).forEach { account in
+                account.isBackedUp = true
+                session?.authenticatedUser?.updateAccount(account)
+            }
+        }
 
         if let cachedAccount = sharedDataController.accountCollection[account.address]?.value {
             cachedAccount.isBackedUp = true


### PR DESCRIPTION
When the user does a passphrase backup for a hd wallet account, all the accounts from the same wallet will also be backup