### PR TITLE
Fixing title-about string

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -7282,7 +7282,14 @@
       }
     },
     "title-about" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        }
+      }
     },
     "title-about-with-param" : {
       "extractionState" : "manual",


### PR DESCRIPTION
# Pull Request Template

## Description
the key "title-about" is being displayed in the asset view screen when it should be showing "About", this PR fixes this issue.

Currently:
<img width="362" alt="Screenshot 2025-05-06 at 11 16 47 AM" src="https://github.com/user-attachments/assets/1ab45e4c-970c-4199-9fad-fd2c4237c65b" />

Pull Request:

<img width="358" alt="Screenshot 2025-05-06 at 11 17 33 AM" src="https://github.com/user-attachments/assets/b8f7efee-2012-48f1-8268-289ed7294461" />