### PR TITLE
[IOS] - HD Wallet - QA Finding  26 - Trying to swap with a rekeyed to Ledger account makes the app crash

### DIFF
--- a/Classes/Swap/Auxiliaries/Flow/SwapAssetFlowCoordinator.swift
+++ b/Classes/Swap/Auxiliaries/Flow/SwapAssetFlowCoordinator.swift
@@ -562,25 +562,25 @@ extension SwapAssetFlowCoordinator {
 }
 
 extension SwapAssetFlowCoordinator {
-     private func openSignWithLedgerConfirmation(
+    private func openSignWithLedgerConfirmation(
         swapController: SwapController,
         transactionGroups: [SwapTransactionGroup]
-     ) {
+    ) {
         let transition = BottomSheetTransition(presentingViewController: visibleScreen)
-
+        
         let totalTransactionCountToSign = transactionGroups.reduce(0, { $0 + $1.transactionsToSign.count })
-
+        
         let title =
-            String(localized: "swap-sign-with-ledger-title")
-                .bodyLargeMedium(alignment: .center)
-        let highlightedBodyPart = String(format: String(localized: "swap-sign-with-ledger-body-highlighted"), totalTransactionCountToSign)
+        String(localized: "swap-sign-with-ledger-title")
+            .bodyLargeMedium(alignment: .center)
+        let highlightedBodyPart = String(localized: "swap-sign-with-ledger-body-highlighted-\(totalTransactionCountToSign)")
         let body = String(format: String(localized: "swap-sign-with-ledger-body"), totalTransactionCountToSign)
-                .bodyRegular(alignment: .center)
-                .addAttributes(
-                    to: highlightedBodyPart,
-                    newAttributes: Typography.bodyMediumAttributes(alignment: .center)
-                )
-
+            .bodyRegular(alignment: .center)
+            .addAttributes(
+                to: highlightedBodyPart,
+                newAttributes: Typography.bodyMediumAttributes(alignment: .center)
+            )
+        
         let uiSheet = UISheet(
             image: "icon-ledger-48",
             title: title,
@@ -603,7 +603,7 @@ extension SwapAssetFlowCoordinator {
         }
         uiSheet.addAction(signTransactionsAction)
 
-         transition.perform(
+        transition.perform(
             .sheetAction(
                 sheet: uiSheet,
                 theme: UISheetActionScreenImageTheme()

--- a/Classes/Transactions/Send/Inbox/SendAssetInboxScreen.swift
+++ b/Classes/Transactions/Send/Inbox/SendAssetInboxScreen.swift
@@ -565,21 +565,21 @@ extension SendAssetInboxScreen {
 }
 
 extension SendAssetInboxScreen {
-     private func openSignWithLedgerConfirmation() {
+    private func openSignWithLedgerConfirmation() {
         let transition = BottomSheetTransition(presentingViewController: self)
 
         let totalTransactionCountToSign = 3 // transactionGroups.reduce(0, { $0 + $1.transactionsToSign.count })
 
         let title =
-            String(localized: "swap-sign-with-ledger-title")
-                .bodyLargeMedium(alignment: .center)
-        let highlightedBodyPart = String(format: String(localized: "swap-sign-with-ledger-body-highlighted"), "\(totalTransactionCountToSign)")
+        String(localized: "swap-sign-with-ledger-title")
+            .bodyLargeMedium(alignment: .center)
+        let highlightedBodyPart = String(localized: "swap-sign-with-ledger-body-highlighted-\(totalTransactionCountToSign)")
         let body = String(format: String(localized: "swap-sign-with-ledger-body"), "\(totalTransactionCountToSign)")
-                .bodyRegular(alignment: .center)
-                .addAttributes(
-                    to: highlightedBodyPart,
-                    newAttributes: Typography.bodyMediumAttributes(alignment: .center)
-                )
+            .bodyRegular(alignment: .center)
+            .addAttributes(
+                to: highlightedBodyPart,
+                newAttributes: Typography.bodyMediumAttributes(alignment: .center)
+            )
 
         let uiSheet = UISheet(
             image: "icon-ledger-48",
@@ -597,10 +597,10 @@ extension SendAssetInboxScreen {
             self.openLedgerConnection()
             self.getTransactionParamsAndComposeRelatedTransactions()
         }
-         
+        
         uiSheet.addAction(signTransactionsAction)
 
-         transition.perform(
+        transition.perform(
             .sheetAction(
                 sheet: uiSheet,
                 theme: UISheetActionScreenImageTheme()

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -7648,12 +7648,26 @@
       }
     },
     "swap-sign-with-ledger-body-highlighted" : {
-      "extractionState" : "manual",
+
+    },
+    "swap-sign-with-ledger-body-highlighted-%lld" : {
       "localizations" : {
         "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You will need to sign %@ transactions one by one"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "You will need to sign %lld transaction"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "You will need to sign %lld transactions one by one"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
- Removed String(format:) from the lines where "swap-sign-with-ledger-body-highlighted" is called.
- Added %lld input type to swap-sign-with-ledger-body-highlighted key.
- Replaced object type with long long integer in swap-sign-with-ledger-body-highlighted localized string.
- Set swap-sign-with-ledger-body-highlighted to be managed automatically.
- Added singular form for the swap-sign-with-ledger-body-highlighted.
- Aligned several lines in the code.