### PR TITLE
[IOS] Navigation Redesign - Finding 1 - MENU button not responsive while user is on settings page

### DIFF
--- a/Classes/Application/Core/Container/TabBar/TabBarController.swift
+++ b/Classes/Application/Core/Container/TabBar/TabBarController.swift
@@ -163,6 +163,20 @@ final class TabBarController: TabBarContainer {
     override func viewDidLoad() {
         super.viewDidLoad()
         customizeViewAppearance([.backgroundColor(Colors.Defaults.background)])
+        
+        itemDidSelect = { [weak self] index in
+            guard let self else { return }
+            guard
+                selectedIndex == index,
+                let nav = selectedScreen as? UINavigationController,
+                nav.viewControllers.count > 1 else
+            {
+                selectedIndex = index
+                return
+            }
+                
+            nav.popToRootViewController(animated: true)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -191,6 +205,8 @@ final class TabBarController: TabBarContainer {
             analytics.track(.tabBarPressed(type: .tapMenu))
         case .stake:
             analytics.track(.tabBarPressed(type: .tapStake))
+        case .collectibles:
+            analytics.track(.tabBarPressed(type: .tapNFTs))
         default:
             break
         }


### PR DESCRIPTION
When the user presses the tab button for a tab already open, if the root view controller is not showing, pop all the view controllers until root view controller is shown