### PR TITLE
[iOS] The bottom bar hides when one clicks on the 'stake' link from the banner, though it works fine when one clicks directly from the bottom bar

### DIFF
--- a/Classes/Routing/Router.swift
+++ b/Classes/Routing/Router.swift
@@ -472,14 +472,7 @@ final class Router:
                     launch(tab: .discover)
                 }
             case .staking:
-                findVisibleScreen(over: rootViewController).open(
-                    .staking,
-                    by: .customPresentWithoutNavigationController(
-                        presentationStyle: .fullScreen,
-                        transitionStyle: nil,
-                        transitioningDelegate: nil
-                    )
-                )
+                launch(tab: .stake)
             case .cards(path: let path):
                 let isCardsFeatureEnabled = Environment.current.isCardsFeatureEnabled(
                     for: appConfiguration.api.network


### PR DESCRIPTION
Fix stake screen navigation from deeplink