### PR TITLE
[IOS] - HD Account Import - Do not show rekey information if there are no rekeyed accounts

### DIFF
--- a/Classes/Accounts/AccountDiscovery/SelectAddress/Screens/SelectAddressViewController.swift
+++ b/Classes/Accounts/AccountDiscovery/SelectAddress/Screens/SelectAddressViewController.swift
@@ -255,7 +255,7 @@ extension SelectAddressViewController {
         }
         
         let accounts = accountsInfos.map { Account(localAccount: $0) }
-        rescanRekeyedAccountsCoordinator.rescan(accounts: accounts, nextStep: .openAddAccountTutorial(isMultipleAccounts: dataController.selectedAddresses.count > 1))
+        rescanRekeyedAccountsCoordinator.rescan(accounts: accounts, nextStep: .returnToHomeScreen)
     }
 }
 

--- a/Classes/Demo/RescanRekeyedAccountsCoordinator.swift
+++ b/Classes/Demo/RescanRekeyedAccountsCoordinator.swift
@@ -100,8 +100,15 @@ final class RescanRekeyedAccountsCoordinator {
     
     private func handle(data: [RecoveredAccountsListModel.InputData], nextStep: RecoveredAccountsListView.NextStep) async {
         await MainActor.run {
+            
             presenter?.loadingController?.stopLoading()
-            openAccountsSelectionList(data: data, nextStep: nextStep)
+            
+            if data.isEmpty, nextStep == .returnToHomeScreen {
+                PeraUserDefaults.shouldShowNewAccountAnimation = true
+                presenter?.launchMain()
+            } else {
+                openAccountsSelectionList(data: data, nextStep: nextStep)
+            }
         }
     }
     

--- a/Scenes/Recovered Accounts List/RecoveredAccountsListView.swift
+++ b/Scenes/Recovered Accounts List/RecoveredAccountsListView.swift
@@ -18,9 +18,9 @@ import SwiftUI
 
 struct RecoveredAccountsListView: View {
     
-    enum NextStep {
+    enum NextStep: Equatable {
         case dismiss
-        case openAddAccountTutorial(isMultipleAccounts: Bool)
+        case returnToHomeScreen
     }
     
     // MARK: - Properties
@@ -80,7 +80,7 @@ struct RecoveredAccountsListView: View {
                 FormButton(text: "rekeyed-account-selection-list-primary-action-title", style: model.isAddressSelected ? .primary : .disabled) { model.confirmSelection() }
                     .padding(.bottom, 12.0)
             }
-            FormButton(text: model.addressViewModels.isEmpty ? "title-continue" : "rekeyed-account-selection-list-secondary-action-title", style: .secondary) { skipScreen() }
+            FormButton(text: model.addressViewModels.isEmpty ? "title-continue" : "rekeyed-account-selection-list-secondary-action-title", style: .secondary) { moveToNextStep(success: false) }
                 .padding(.bottom, 16.0)
             
         }
@@ -97,26 +97,17 @@ struct RecoveredAccountsListView: View {
         
         switch action {
         case .endWithSuccess:
-            handleSuccess()
+            moveToNextStep(success: true)
         case let .showDetails(account, authAccount):
             openDetails?(account, authAccount)
         }
     }
     
-    private func handleSuccess() {
+    private func moveToNextStep(success: Bool) {
         switch nextStep {
         case .dismiss:
-            dismiss?(true)
-        case .openAddAccountTutorial:
-            fininshRecoveringAccounts?()
-        }
-    }
-    
-    private func skipScreen() {
-        switch nextStep {
-        case .dismiss:
-            dismiss?(false)
-        case .openAddAccountTutorial:
+            dismiss?(success)
+        case .returnToHomeScreen:
             fininshRecoveringAccounts?()
         }
     }


### PR DESCRIPTION
- The App will now skip the recovery of the rekeyed accounts step in the recovery flow if there aren't any rekeyed accounts on the list.