### PR TITLE
fix: switch to POST request to avoid 414 error

### DIFF
--- a/Classes/API/ALGAPI/ALGAPI+Charts.swift
+++ b/Classes/API/ALGAPI/ALGAPI+Charts.swift
@@ -78,8 +78,8 @@ extension ALGAPI {
         EndpointBuilder(api: self)
             .base(.mobileV1(network))
             .path(.walletWealthBalanceChartData)
-            .query(WalletWealthBalanceChartDataDraft(accountAddresses: addresses, period: period, ordering: ordering))
-            .method(.get)
+            .method(.post)
+            .body(WalletWealthBalanceChartDataDraft(accountAddresses: addresses, period: period))
             .completionHandler(handler)
             .execute()
     }

--- a/Classes/API/Drafts/Charts/WalletWealthBalanceChartDataDraft.swift
+++ b/Classes/API/Drafts/Charts/WalletWealthBalanceChartDataDraft.swift
@@ -16,21 +16,15 @@
 
 import MagpieCore
 
-struct WalletWealthBalanceChartDataDraft: ObjectQuery {
+struct WalletWealthBalanceChartDataDraft: JSONObjectBody {
     var accountAddresses: [String]
     var period: ChartDataPeriod
-    var ordering: String?
     
-    var queryParams: [APIQueryParam] {
-        var params: [APIQueryParam] = []
+    var bodyParams: [APIBodyParam] {
+        var params: [APIBodyParam] = []
 
-        params.append(APIQueryParam(.accountAddresses, accountAddresses))
-        
-        params.append(APIQueryParam(.period, period.rawValue))
-        
-        if let ordering {
-            params.append(APIQueryParam(.ordering, ordering))
-        }
+        params.append(APIBodyParam(.accountAddresses, accountAddresses))
+        params.append(APIBodyParam(.period, period.rawValue))
 
         return params
     }


### PR DESCRIPTION
# Pull Request Template

## Description
Converts the portfolio chart to using the POST endpoint in order to avoid 414 Request URL Too Long errors on wallets with lots of addresses.

## Related Issues
Closes https://algorandfoundation.atlassian.net/browse/PERA-2677

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
None
