### PR TITLE
[iOS] Chart y-axis domain too big for small values

### DIFF
--- a/Classes/Charts/Views/LineChartView.swift
+++ b/Classes/Charts/Views/LineChartView.swift
@@ -27,7 +27,7 @@ struct LineChartView: View {
     var body: some View {
         let maxValue = data.map(\.value).max() ?? 100
         let minValue = data.map(\.value).min() ?? 0
-        let yDomain = (minValue - 10)...(maxValue + 10)
+        let yDomain = (minValue * 0.99)...(maxValue * 1.01)
         
         GeometryReader { geo in
             let chart = Chart {


### PR DESCRIPTION
When the chart values are too small (less then 1.0) the y-axis domain is too big and we see a flat line

Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 17 47 09" src="https://github.com/user-attachments/assets/a884dc4a-28da-4a71-9491-37f56a2f627a" />

After:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 17 47 54" src="https://github.com/user-attachments/assets/cf217242-5a73-4e6f-8738-33a8e0eca331" />
