### PR TITLE
Share Extensions for Pera 

### DIFF
--- a/Classes/Application/AppDelegate.swift
+++ b/Classes/Application/AppDelegate.swift
@@ -182,6 +182,23 @@ class AppDelegate:
 
             return true
         }
+        print("ynyn")
+        if let scheme = url.scheme,
+            scheme.caseInsensitiveCompare("perawallet") == .orderedSame {
+            
+            let urlString = "https:" + url
+                .absoluteString
+                .replacingOccurrences(
+                    of: "perawallet:",
+                    with: ""
+                )
+ 
+            if let externalURL = URL(string: urlString) {
+                let destination = DiscoverExternalDestination.url(externalURL)
+                receive(deeplinkWithSource: .externalInAppBrowser(destination))
+                return true
+            }
+        }
         
         if let browserURL = url.browserDeeplinkURL {
             let destination = DiscoverExternalDestination.url(browserURL)

--- a/Classes/Application/AppDelegate.swift
+++ b/Classes/Application/AppDelegate.swift
@@ -182,7 +182,7 @@ class AppDelegate:
 
             return true
         }
-        print("ynyn")
+
         if let scheme = url.scheme,
             scheme.caseInsensitiveCompare("perawallet") == .orderedSame {
             

--- a/algorand.xcodeproj/project.pbxproj
+++ b/algorand.xcodeproj/project.pbxproj
@@ -3573,6 +3573,7 @@
 		2BFFEA0425DD33E00009F30C /* PassphraseVerifyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFFEA0325DD33E00009F30C /* PassphraseVerifyDataSource.swift */; };
 		2BFFEA0525DD33E00009F30C /* PassphraseVerifyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFFEA0325DD33E00009F30C /* PassphraseVerifyDataSource.swift */; };
 		2BFFEA0625DD33E00009F30C /* PassphraseVerifyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFFEA0325DD33E00009F30C /* PassphraseVerifyDataSource.swift */; };
+		3AC4B5522E4586730038E911 /* peraShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3AC4B5472E4586730038E911 /* peraShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		543447762D5355820080AF4D /* OptOutAssetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543447752D5355800080AF4D /* OptOutAssetCoordinator.swift */; };
 		543447772D5355820080AF4D /* OptOutAssetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543447752D5355800080AF4D /* OptOutAssetCoordinator.swift */; };
 		543447782D5355820080AF4D /* OptOutAssetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543447752D5355800080AF4D /* OptOutAssetCoordinator.swift */; };
@@ -8249,7 +8250,28 @@
 			remoteGlobalIDString = 17BD4DEE2292F1260003E49A;
 			remoteInfo = "algorand-staging";
 		};
+		3AC4B54F2E4586730038E911 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B8BE4C622391C38005D8565 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AC4B5462E4586730038E911;
+			remoteInfo = peraShare;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3AC4B5512E4586730038E911 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				3AC4B5522E4586730038E911 /* peraShare.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0414ACC52721691100475F8E /* QRCreationViewTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCreationViewTheme.swift; sourceTree = "<group>"; };
@@ -9475,6 +9497,7 @@
 		2BFA924729CCCCEC0097E1B1 /* OptInAssetListErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInAssetListErrorViewModel.swift; sourceTree = "<group>"; };
 		2BFA924B29CCCE320097E1B1 /* OptInAssetNextListErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInAssetNextListErrorViewModel.swift; sourceTree = "<group>"; };
 		2BFFEA0325DD33E00009F30C /* PassphraseVerifyDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseVerifyDataSource.swift; sourceTree = "<group>"; };
+		3AC4B5472E4586730038E911 /* peraShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = peraShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		543447752D5355800080AF4D /* OptOutAssetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptOutAssetCoordinator.swift; sourceTree = "<group>"; };
 		5435EC6F2E126A970056A49D /* RekeySupportOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RekeySupportOverlayViewController.swift; sourceTree = "<group>"; };
 		5435EC732E126B170056A49D /* RekeySupportOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RekeySupportOverlayView.swift; sourceTree = "<group>"; };
@@ -11012,6 +11035,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		3AC4B5572E4586730038E911 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 3AC4B5462E4586730038E911 /* peraShare */;
+		};
 		543FBF982DF6C56500E9522E /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -11126,6 +11156,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		3AC4B5482E4586730038E911 /* peraShare */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3AC4B5572E4586730038E911 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = peraShare; sourceTree = "<group>"; };
 		5449C7C52DDB4AE600E63A8F /* Scenes */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Scenes; sourceTree = "<group>"; };
 		5458D85A2DEDB35700DADA06 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
 		5458D8682DEDB35700DADA06 /* Managers */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (543FBF9E2DF6C5D700E9522E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 543FBF9F2DF6C5D700E9522E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 543FBFA02DF6C5D700E9522E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Managers; sourceTree = "<group>"; };
@@ -11265,6 +11296,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2B95407425A75FB20098805B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AC4B5442E4586730038E911 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -14504,6 +14542,7 @@
 				2B191C882321998100EAB1B8 /* algorand-staging.entitlements */,
 				2B8BE4D022391C38005D8565 /* Classes */,
 				2B95407825A75FB20098805B /* algorand-tests */,
+				3AC4B5482E4586730038E911 /* peraShare */,
 				9F18DC6D0E56430348850CDE /* Frameworks */,
 				17512612223BDC2B0095AF4F /* Libraries */,
 				2B8BE4CF22391C38005D8565 /* Products */,
@@ -14520,6 +14559,7 @@
 				17BD4F252292F1260003E49A /* pera-staging.app */,
 				2B0F634E24EC129D00DA22A6 /* pera-beta.app */,
 				2B95407725A75FB20098805B /* pera-tests.xctest */,
+				3AC4B5472E4586730038E911 /* peraShare.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -24378,10 +24418,12 @@
 				2B8BE4CB22391C38005D8565 /* Frameworks */,
 				2B8BE4CC22391C38005D8565 /* Resources */,
 				2B096039225795170005BE27 /* Run Script */,
+				3AC4B5512E4586730038E911 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3AC4B5502E4586730038E911 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				5449C7C52DDB4AE600E63A8F /* Scenes */,
@@ -24450,13 +24492,35 @@
 			productReference = 2B95407725A75FB20098805B /* pera-tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		3AC4B5462E4586730038E911 /* peraShare */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AC4B5562E4586730038E911 /* Build configuration list for PBXNativeTarget "peraShare" */;
+			buildPhases = (
+				3AC4B5432E4586730038E911 /* Sources */,
+				3AC4B5442E4586730038E911 /* Frameworks */,
+				3AC4B5452E4586730038E911 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3AC4B5482E4586730038E911 /* peraShare */,
+			);
+			name = peraShare;
+			packageProductDependencies = (
+			);
+			productName = peraShare;
+			productReference = 3AC4B5472E4586730038E911 /* peraShare.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		2B8BE4C622391C38005D8565 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1220;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = hippo;
 				TargetAttributes = {
@@ -24479,6 +24543,9 @@
 					2B95407625A75FB20098805B = {
 						CreatedOnToolsVersion = 12.2;
 						TestTargetID = 17BD4DEE2292F1260003E49A;
+					};
+					3AC4B5462E4586730038E911 = {
+						CreatedOnToolsVersion = 16.4;
 					};
 				};
 			};
@@ -24515,6 +24582,7 @@
 				2B0F615A24EC129D00DA22A6 /* pera-beta */,
 				17BD4DEE2292F1260003E49A /* pera-staging */,
 				2B95407625A75FB20098805B /* pera-tests */,
+				3AC4B5462E4586730038E911 /* peraShare */,
 			);
 		};
 /* End PBXProject section */
@@ -24700,6 +24768,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3AC4B5452E4586730038E911 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -24729,7 +24804,6 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = "Run Script";
 			outputFileListPaths = (
@@ -32780,6 +32854,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3AC4B5432E4586730038E911 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -32787,6 +32868,11 @@
 			isa = PBXTargetDependency;
 			target = 17BD4DEE2292F1260003E49A /* pera-staging */;
 			targetProxy = 2B95407C25A75FB20098805B /* PBXContainerItemProxy */;
+		};
+		3AC4B5502E4586730038E911 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3AC4B5462E4586730038E911 /* peraShare */;
+			targetProxy = 3AC4B54F2E4586730038E911 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -33240,6 +33326,106 @@
 			};
 			name = "App Store";
 		};
+		3AC4B5532E4586730038E911 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = peraShare/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = peraShare;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 hippo. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.algorandllc.algorand.peraShare;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3AC4B5542E4586730038E911 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 87QL82XC78;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = peraShare/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = peraShare;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 hippo. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.algorandllc.algorand.peraShare;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3AC4B5552E4586730038E911 /* App Store */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 87QL82XC78;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = peraShare/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = peraShare;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 hippo. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.algorandllc.algorand.peraShare;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "App Store";
+		};
 		EC6B733422541CA8006D146B /* App Store */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2B3BC385266FEBCD007D7107 /* Config.xcconfig */;
@@ -33380,6 +33566,16 @@
 				2B95407E25A75FB20098805B /* Debug */,
 				2B95407F25A75FB20098805B /* Release */,
 				2B95408025A75FB20098805B /* App Store */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AC4B5562E4586730038E911 /* Build configuration list for PBXNativeTarget "peraShare" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AC4B5532E4586730038E911 /* Debug */,
+				3AC4B5542E4586730038E911 /* Release */,
+				3AC4B5552E4586730038E911 /* App Store */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/peraShare/Info.plist
+++ b/peraShare/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>NSExtensionActivationRule</key>
+            <dict>
+                <key>NSExtensionActivationSupportsText</key>
+                <true/>
+                <key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+                <integer>1</integer>
+            </dict>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.share-services</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>peraShare.ShareViewController</string>
+    </dict>
+</dict>
+</plist>

--- a/peraShare/ShareViewController.swift
+++ b/peraShare/ShareViewController.swift
@@ -1,0 +1,65 @@
+//
+//  ShareViewController.swift
+//  peraShare
+//
+//  Created by Yuliani Noriega on 6/8/25.
+//
+
+import UIKit
+import UniformTypeIdentifiers
+
+class ShareViewController: UIViewController {
+
+    private let typeURL = UTType.url.identifier
+    private let appURL = "perawallet://"
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        guard let extensionItem = extensionContext?.inputItems.first as? NSExtensionItem,
+            let itemProvider = extensionItem.attachments?.first else {
+                self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+                return
+        }
+
+        if itemProvider.hasItemConformingToTypeIdentifier(typeURL) {
+            handleIncomingURL(itemProvider: itemProvider)
+        } else {
+            print("Error: No url or text found")
+            self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+        }
+    }
+
+    private func handleIncomingURL(itemProvider: NSItemProvider) {
+        itemProvider.loadItem(forTypeIdentifier: typeURL, options: nil) { (item, error) in
+            if let error = error { print("URL-Error: \(error.localizedDescription)") }
+            var urlString = ""
+            if let url = item as? URL {
+                urlString = url.host! + url.path
+            }
+            
+            self.openMainApp(urlString: urlString)
+        }
+    }
+
+    private func openMainApp(urlString: String) {
+        self.extensionContext?.completeRequest(returningItems: nil, completionHandler: { _ in
+            guard let url = URL(string: self.appURL + urlString) else { return }
+            _ = self.openURL(url)
+        })
+    }
+
+    // Courtesy: https://stackoverflow.com/a/44499222/13363449 👇🏾
+    // Function must be named exactly like this so a selector can be found by the compiler!
+    // Anyway - it's another selector in another instance that would be "performed" instead.
+    @objc @discardableResult private func openURL(_ url: URL) -> Bool {
+        var responder: UIResponder? = self
+        while responder != nil {
+            if let application = responder as? UIApplication {
+                application.open(url, options: [:], completionHandler: nil)
+            }
+            responder = responder?.next
+        }
+        return false
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description
This PR implements Share Extensions for Pera to appear as an option to open URLs directly from the share dialog.  

It's a proof of concept for the Pera team to evaluate if they would like to enable this functionality for its users.
![shareExtension](https://github.com/user-attachments/assets/135ab35d-d513-46a6-80f8-9944566c27d3)

## Related Issues
- Removed the input file `INFOPLIST_PATH` for crashlytics's run script to get this to compile & build correctly.
- Tried to follow the naming pattern for the targets `pera-share` but the dash in the name was having issues and so I went with a uppercase `peraShare`
<img width="1198" height="613" alt="Screenshot 2025-08-07 at 9 12 36 PM" src="https://github.com/user-attachments/assets/c6add98f-c862-41af-9f20-e8923813c8f8" />


