### PR TITLE
fix: add accessibility id to settings back button for testability

### DIFF
--- a/PeraWallet/Scenes/Settings/Settings List/SettingsListView.swift
+++ b/PeraWallet/Scenes/Settings/Settings List/SettingsListView.swift
@@ -106,6 +106,7 @@ struct SettingsListView: View {
                             Image(.iconBack)
                                 .foregroundStyle(Color.Text.main)
                         }
+                        .accessibilityIdentifier(ViewIdentifier.settingsNavigationBack.rawValue)
                     }
                 )
             }

--- a/PeraWallet/Utils/Constants/ViewIdentifier.swift
+++ b/PeraWallet/Utils/Constants/ViewIdentifier.swift
@@ -19,4 +19,5 @@ enum ViewIdentifier: String {
     // MARK: - Home Scene
     
     case homeConfettiAnimation = "home.animation.confetti"
+    case settingsNavigationBack = "settings.navigation.back"
 }


### PR DESCRIPTION
# Pull Request Template

## Description
Adds an accessibility Id to the settings back button to assist with locating during browserstack tests.

## Related Issues
N/A

## Checklist
- [X] Have you tested your changes locally?
- [ ] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
