### PR TITLE
fix: improve error handling and logging for migration failures

### DIFF
--- a/PassKeyExtension/CredentialProviderService.swift
+++ b/PassKeyExtension/CredentialProviderService.swift
@@ -85,7 +85,7 @@ final class CredentialProviderService {
     }
     
     private func initializeExtension() throws {
-        CoreAppConfiguration.initialize()
+        try CoreAppConfiguration.initialize()
         passKeyManager = try createPassKeyService()
     }
     

--- a/PeraWallet/Classes/Application/AppDelegate.swift
+++ b/PeraWallet/Classes/Application/AppDelegate.swift
@@ -486,7 +486,18 @@ extension AppDelegate {
         biometricAuthenticationMigration.migratePasswordToKeychain()
         
         let dataStoreMigration = AppGroupDataStoreMigration(appGroup: ALGAppTarget.current.appGroupIdentifier)
-        dataStoreMigration.moveDatabaseToAppGroup()
+        
+        do {
+            try dataStoreMigration.moveDatabaseToAppGroup()
+        } catch AppGroupDataStoreMigrationError.migrationFailed(let cause), AppGroupDataStoreMigrationError.contentNotDetected(let cause) {
+            CoreAppConfiguration.shared?.analytics.record(MigrationFailureLog.migrationFailure(message: "Migration failed", cause: cause))
+            //TODO: ideally this should redirect to a user visible page, but we don't have such a page so for now it's safest to crash
+            assertionFailure("AppGroup data migration failed")
+        } catch {
+            CoreAppConfiguration.shared?.analytics.record(MigrationFailureLog.migrationFailure(message: "Migration failed", cause: error))
+            //TODO: ideally this should redirect to a user visible page, but we don't have such a page so for now it's safest to crash
+            assertionFailure("AppGroup data migration failed")
+        }
     }
     
     private func setupLegacyBridge() {
@@ -632,14 +643,19 @@ extension AppDelegate {
         CoreAppConfiguration.shared = config
         
         if let shared = CoreAppConfiguration.shared {
-            shared.persistentContainer = createPersistentContainer()
+            do {
+                shared.persistentContainer = try createPersistentContainer()
+            } catch {
+                //TODO: ideally we should go to a user visible error, but we have no such page, so for now we have to crash
+                assertionFailure("Failed to initialize database: \(error)")
+            }
         }
         
         return config;
     }
     
-    private func createPersistentContainer() -> NSPersistentContainer {
-        NSPersistentContainer.makePersistentContainer(
+    private func createPersistentContainer() throws -> NSPersistentContainer {
+        try NSPersistentContainer.makePersistentContainer(
             group: ALGAppTarget.current.appGroupIdentifier)
     }
     

--- a/PeraWalletCore/Analytics/Core/ALGAnalyticsLog.swift
+++ b/PeraWalletCore/Analytics/Core/ALGAnalyticsLog.swift
@@ -50,6 +50,8 @@ public enum ALGAnalyticsLogName:
     case walletConnectV2SessionDisconnectionFailed = "WCv2SessionDisconnectionFailed"
     case walletConnectV2TransactionRequestApprovalFailed = "WCv2TransactionRequestApprovalFailed"
     case walletConnectV2TransactionRequestRejectionFailed = "WCv2TransactionRequestRejectionFailed"
+    case migrationFailure = "MigrationFailure"
+    case persistentContainerCreationError = "PersistentContainerCreationError"
     
     public static func ==(lhs: ALGAnalyticsLogName, rhs: ALGAnalyticsLogName) -> Bool {
         lhs.rawValue == rhs.rawValue
@@ -82,6 +84,8 @@ extension ALGAnalyticsLogName {
         case .walletConnectTransactionFailToConnectError: return 16
         case .walletConnectTransactionApprovalFailedError: return 17
         case .walletConnectTransactionRejectionFailedError: return 18
+        case .migrationFailure: return 19
+        case .persistentContainerCreationError: return 20
         }
     }
 }

--- a/PeraWalletCore/Analytics/Core/ALGAnalyticsMetadata.swift
+++ b/PeraWalletCore/Analytics/Core/ALGAnalyticsMetadata.swift
@@ -78,6 +78,10 @@ public enum ALGAnalyticsMetadataKey:
     case screenName = "screen"
     case bannerName = "banner_name"
     case wcActionError = "wc_action_error"
+    case errorDetails = "error_details"
+    case errorCause = "error_root_cause"
+    case appGroupName = "app_group_name"
+    
     
     public static func == (lhs: ALGAnalyticsMetadataKey, rhs: ALGAnalyticsMetadataKey) -> Bool {
         lhs.rawValue == rhs.rawValue

--- a/PeraWalletCore/Analytics/Logs/MigrationFailureLog.swift
+++ b/PeraWalletCore/Analytics/Logs/MigrationFailureLog.swift
@@ -1,0 +1,48 @@
+// Copyright 2022-2025 Pera Wallet, LDA
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//  LedgerTransactionErrorLog.swift
+
+import Foundation
+import MacaroonVendors
+
+/// <note>: MigrationFailureLog description below
+/// When a migration fails we want to capture as much data about the failure as possible to debug
+public struct MigrationFailureLog: ALGAnalyticsLog {
+    public let name: ALGAnalyticsLogName
+    public let metadata: ALGAnalyticsMetadata
+    
+    fileprivate init(
+        message: String,
+        cause: Error?
+    ) {
+        self.name = .migrationFailure
+        self.metadata = [
+            .errorDetails: "\(message)",
+            .errorCause: "\(cause ?? "No cause")"
+        ]
+    }
+}
+
+extension ALGAnalyticsLog where Self == MigrationFailureLog {
+    public static func migrationFailure(
+        message: String,
+        cause: Error?
+    ) -> Self {
+        return MigrationFailureLog(
+            message: message,
+            cause: cause
+        )
+    }
+}

--- a/PeraWalletCore/Analytics/Logs/PersitentContainerCreationError.swift
+++ b/PeraWalletCore/Analytics/Logs/PersitentContainerCreationError.swift
@@ -1,0 +1,48 @@
+// Copyright 2022-2025 Pera Wallet, LDA
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//  LedgerTransactionErrorLog.swift
+
+import Foundation
+import MacaroonVendors
+
+/// <note>: PersitentContainerCreationError description below
+/// When a migration fails we want to capture as much data about the failure as possible to debug
+public struct PersitentContainerCreationError: ALGAnalyticsLog {
+    public let name: ALGAnalyticsLogName
+    public let metadata: ALGAnalyticsMetadata
+    
+    fileprivate init(
+        appGroup: String,
+        errorDetails: String
+    ) {
+        self.name = .persistentContainerCreationError
+        self.metadata = [
+            .errorDetails: "\(errorDetails)",
+            .appGroupName: appGroup
+        ]
+    }
+}
+
+extension ALGAnalyticsLog where Self == PersitentContainerCreationError {
+    public static func persistentContainerCreationError(
+        appGroup: String,
+        errorDetails: String
+    ) -> Self {
+        return PersitentContainerCreationError(
+            appGroup: appGroup,
+            errorDetails: errorDetails
+        )
+    }
+}

--- a/PeraWalletCore/Utils/Configuration/CoreAppConfiguration.swift
+++ b/PeraWalletCore/Utils/Configuration/CoreAppConfiguration.swift
@@ -63,13 +63,13 @@ open class CoreAppConfiguration {
 
 // This class performs the same function as the AppDelegate in a normal app (i.e. initialize the world)
 extension CoreAppConfiguration {
-    public static func initialize() {
+    public static func initialize() throws {
         if CoreAppConfiguration.shared != nil {
             return
         }
         
         ALGAppTarget.setup()
-        let persistentContainer: NSPersistentContainer = NSPersistentContainer.makePersistentContainer(
+        let persistentContainer: NSPersistentContainer = try NSPersistentContainer.makePersistentContainer(
             group: ALGAppTarget.current.appGroupIdentifier)
         let featureFlagService = makeFeatureFlagService()
         let hdWalletService = makeHDWalletService()

--- a/PeraWalletCore/Utils/Extensions/Data/NSPersistentContainer+Create.swift
+++ b/PeraWalletCore/Utils/Extensions/Data/NSPersistentContainer+Create.swift
@@ -17,11 +17,11 @@ import CoreData
 extension NSPersistentContainer {
     public static let DEFAULT_CONTAINER_NAME = "algorand"
     
-    public static func makePersistentContainer(group: String?) -> NSPersistentContainer {
+    public static func makePersistentContainer(group: String?) throws -> NSPersistentContainer {
         let container = NSPersistentContainer(name: DEFAULT_CONTAINER_NAME)
         
         if let group {
-            let storeURL = URL.appGroupDBURL(for: group, databaseName: DEFAULT_CONTAINER_NAME)
+            let storeURL = try URL.appGroupDBURL(for: group, databaseName: DEFAULT_CONTAINER_NAME)
             let storeDescription = NSPersistentStoreDescription(url: storeURL)
             container.persistentStoreDescriptions = [storeDescription]
         }
@@ -34,6 +34,8 @@ extension NSPersistentContainer {
             }
 
             if let error = error as NSError? {
+                CoreAppConfiguration.shared?.analytics.record(
+                    PersitentContainerCreationError.persistentContainerCreationError(appGroup: group ?? "nil", errorDetails: "\(error), \(error.code), \(error.userInfo)"))
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         }

--- a/PeraWalletCore/Utils/Extensions/URL/URL+SocialMedia.swift
+++ b/PeraWalletCore/Utils/Extensions/URL/URL+SocialMedia.swift
@@ -21,9 +21,13 @@ public extension URL {
         return URL(string: "https://twitter.com/\(username)")
     }
     
-    static func appGroupDBURL(for appGroup: String, databaseName: String) -> URL {
+    enum AppGroupURLError : Error {
+        case invalid
+    }
+    
+    static func appGroupDBURL(for appGroup: String, databaseName: String) throws -> URL {
         guard let fileContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
-            fatalError("Shared file container could not be created.")
+            throw AppGroupURLError.invalid
         }
 
         return fileContainer.appendingPathComponent("\(databaseName).sqlite")

--- a/algorand.xcodeproj/project.pbxproj
+++ b/algorand.xcodeproj/project.pbxproj
@@ -2929,6 +2929,8 @@
 		5916815F2E4A2D83002184C2 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591674632E460AA3002184C2 /* ImagePicker.swift */; };
 		591681602E4A34F4002184C2 /* StatusBarConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591674932E460AA3002184C2 /* StatusBarConfigurable.swift */; };
 		591681632E4A51C6002184C2 /* algorand.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 2B59F1372254BABF005203DD /* algorand.xcdatamodeld */; };
+		594D54822E8E6D7700D0DA38 /* MigrationFailureLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594D54812E8E6D7700D0DA38 /* MigrationFailureLog.swift */; };
+		594D54842E8E748800D0DA38 /* PersitentContainerCreationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594D54832E8E748800D0DA38 /* PersitentContainerCreationError.swift */; };
 		5977541A2E570EF20089E103 /* WCTransactionFailToRejectErrorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597754192E570EF20089E103 /* WCTransactionFailToRejectErrorLog.swift */; };
 		5977541B2E570EF20089E103 /* WCTransactionFailToApproveErrorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597754182E570EF20089E103 /* WCTransactionFailToApproveErrorLog.swift */; };
 		5977541D2E570F810089E103 /* WCTransactionFailToConnectErrorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977541C2E570F7A0089E103 /* WCTransactionFailToConnectErrorLog.swift */; };
@@ -8793,6 +8795,8 @@
 		591678AB2E462D4B002184C2 /* Session+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+UI.swift"; sourceTree = "<group>"; };
 		591678AF2E462E95002184C2 /* ErrorDisplayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDisplayable.swift; sourceTree = "<group>"; };
 		591678B72E463C43002184C2 /* CoreAppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreAppConfiguration.swift; sourceTree = "<group>"; };
+		594D54812E8E6D7700D0DA38 /* MigrationFailureLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationFailureLog.swift; sourceTree = "<group>"; };
+		594D54832E8E748800D0DA38 /* PersitentContainerCreationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersitentContainerCreationError.swift; sourceTree = "<group>"; };
 		597754182E570EF20089E103 /* WCTransactionFailToApproveErrorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCTransactionFailToApproveErrorLog.swift; sourceTree = "<group>"; };
 		597754192E570EF20089E103 /* WCTransactionFailToRejectErrorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCTransactionFailToRejectErrorLog.swift; sourceTree = "<group>"; };
 		5977541C2E570F7A0089E103 /* WCTransactionFailToConnectErrorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCTransactionFailToConnectErrorLog.swift; sourceTree = "<group>"; };
@@ -11607,6 +11611,8 @@
 			children = (
 				D4A5336229F6EA2100CBC1A9 /* LedgerAccountSelectionScreenFetchingRekeyingAccountsFailedLog.swift */,
 				2B32A25E2552F031007CC3A6 /* LedgerTransactionErrorLog.swift */,
+				594D54812E8E6D7700D0DA38 /* MigrationFailureLog.swift */,
+				594D54832E8E748800D0DA38 /* PersitentContainerCreationError.swift */,
 				D4A5335E29F6E8C000CBC1A9 /* RecoverAccountWithPassphraseScreenFetchingRekeyingAccountsFailedLog.swift */,
 				597754182E570EF20089E103 /* WCTransactionFailToApproveErrorLog.swift */,
 				5977541C2E570F7A0089E103 /* WCTransactionFailToConnectErrorLog.swift */,
@@ -31094,6 +31100,7 @@
 				5916761C2E460AF9002184C2 /* BuyCryptoEvent.swift in Sources */,
 				5916761D2E460AF9002184C2 /* RegisterAccountEvent.swift in Sources */,
 				5916761E2E460AF9002184C2 /* RekeyAccountEvent.swift in Sources */,
+				594D54842E8E748800D0DA38 /* PersitentContainerCreationError.swift in Sources */,
 				5916761F2E460AF9002184C2 /* ShowAssetDetailEvent.swift in Sources */,
 				591676202E460AF9002184C2 /* ShowQRCopyEvent.swift in Sources */,
 				591676212E460AF9002184C2 /* ShowQRShareCompleteEvent.swift in Sources */,
@@ -31583,6 +31590,7 @@
 				591678532E460AF9002184C2 /* WCTransactionOption.swift in Sources */,
 				59B10C7D2E53259E00B8F6FB /* WebAuthNPassKeyEvent.swift in Sources */,
 				591678542E460AF9002184C2 /* WCTransactionRequestedSigner.swift in Sources */,
+				594D54822E8E6D7700D0DA38 /* MigrationFailureLog.swift in Sources */,
 				591678552E460AF9002184C2 /* WCTransactionErrorResponse.swift in Sources */,
 				591678562E460AF9002184C2 /* Backup.swift in Sources */,
 				591678572E460AF9002184C2 /* IncomingASAsRequestList.swift in Sources */,


### PR DESCRIPTION
# Pull Request Template

## Description
Adds firebase logging in the event of migration failures (specifically the app group migration) and tries to improve the error handling throughout to get rid of some of the `fatalError` cases

## Related Issues
https://algorandfoundation.atlassian.net/browse/PERA-2901

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [X] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
The app will still crash in the event of a failure in this migration, since it's not safe to start the app or move/delete user's data without their knowledge, but we should get more debugging info on future crashes.
