### PR TITLE
PERA-3892 - [IOS] - Joint Account - Finding 28 - Opt In behavior needs to be improved

### DIFF
--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlay.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlay.swift
@@ -28,6 +28,7 @@ struct JointAccountPendingTransactionOverlay: View {
     // MARK: - Properties - UIKit Compatibility
     
     var onDismiss: (() -> Void)?
+    var onCancelTransactionAction: (() -> Void)?
     
     // MARK: - Initialisers
     
@@ -117,6 +118,7 @@ struct JointAccountPendingTransactionOverlay: View {
     
     private func onCancelAction() {
         model.cancelTransaction()
+        onCancelTransactionAction?()
     }
     
     private func onCloseAction() {

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
@@ -31,7 +31,8 @@ enum JointAccountPendingTransactionOverlayConstructor {
         return JointAccountPendingTransactionOverlay(model: model)
     }
     
-    static func buildViewController(signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date, onDismiss: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
+    static func buildViewController(signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo],
+                                    threshold: Int, deadline: Date, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,
             signRequestID: signRequestID,
@@ -40,10 +41,10 @@ enum JointAccountPendingTransactionOverlayConstructor {
             threshold: threshold,
             deadline: deadline
         )
-        return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss)
+        return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
     }
     
-    static func buildViewController(signRequestMetadata: SignRequestMetadata, onDismiss: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
+    static func buildViewController(signRequestMetadata: SignRequestMetadata, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,
             signRequestID: signRequestMetadata.signRequestID,
@@ -52,6 +53,6 @@ enum JointAccountPendingTransactionOverlayConstructor {
             threshold: signRequestMetadata.threshold,
             deadline: signRequestMetadata.deadline
         )
-        return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss)
+        return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
     }
 }

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayViewController.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayViewController.swift
@@ -19,11 +19,13 @@ import SwiftUI
 final class JointAccountPendingTransactionOverlayViewController: UIHostingController<JointAccountPendingTransactionOverlay> {
     
     var onDismiss: (() -> Void)?
+    var onCancelTransaction: (() -> Void)?
     
     // MARK: - Initialisers
     
-    init(rootView: JointAccountPendingTransactionOverlay, onDismiss: (() -> Void)?) {
+    init(rootView: JointAccountPendingTransactionOverlay, onDismiss: (() -> Void)?, onCancelTransaction: (() -> Void)?) {
         self.onDismiss = onDismiss
+        self.onCancelTransaction = onCancelTransaction
         super.init(rootView: rootView)
         setupController()
         setupCallbacks()
@@ -47,6 +49,10 @@ final class JointAccountPendingTransactionOverlayViewController: UIHostingContro
         rootView.onDismiss = { [weak self] in
             self?.dismissScreen()
             self?.onDismiss?()
+        }
+        
+        rootView.onCancelTransactionAction = { [weak self] in
+            self?.onCancelTransaction?()
         }
     }
 }

--- a/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
+++ b/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
@@ -48,26 +48,49 @@ final class JointAccountTransactionCoordinator {
         Task {
             do {
                 let result = try await jointAccountTransactionHandler.handleTransaction(jointAccount: jointAccount, type: transactionType, sharedDataController: sharedDataController, transactionController: transactionController)
-                openPendingTransactionOverlay(signRequestMetadata: result.signRequestMetadata, presenter: presenter)
+                openPendingTransactionOverlay(signRequestMetadata: result.signRequestMetadata, presenter: presenter, jointAccount: jointAccount, transactionType: transactionType, sharedDataController: sharedDataController)
             } catch {
                 action = .failure(error: error, transactionController: transactionController)
             }
         }
     }
     
-    private func openPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata?, presenter: UIViewController) {
+    private func openPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata?, presenter: UIViewController,
+                                               jointAccount: Account, transactionType: JointAccountTransactionHandler.TransactionType, sharedDataController: SharedDataController) {
         
         guard let signRequestMetadata else {
             action = .overlayDismissed
             return
         }
         
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata) { [weak self] in
+        let onDismiss: (() -> Void)? = { [weak self] in
             self?.action = .overlayDismissed
         }
         
+        let onCancelTransaction: (() -> Void)? = { [weak self] in
+            self?.cancelAssetMonitoring(transactionType: transactionType, jointAccount: jointAccount, sharedDataController: sharedDataController)
+        }
+        
+        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
+        
         Task { @MainActor in
             presenter.present(viewController, animated: true)
+        }
+    }
+    
+    private func cancelAssetMonitoring(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, sharedDataController: SharedDataController) {
+        
+        let monitor = sharedDataController.blockchainUpdatesMonitor
+        
+        switch transactionType {
+        case let .optIn(draft):
+            guard let assetIndex = draft.assetIndex else { return }
+            monitor.cancelMonitoringOptInUpdates(forAssetID: assetIndex, for: jointAccount)
+        case let .optOut(draft):
+            guard let assetIndex = draft.assetIndex else { return }
+            monitor.markOptOutUpdatesForNotification(forAssetID: assetIndex, for: jointAccount)
+        case .rekey, .sendAlgos, .sendAsset:
+            break
         }
     }
 }


### PR DESCRIPTION
- JointAccountTransactionCoordinator will now cancel monitoring for opt-in and opt-out assets when user tap on the cancel button on pending transaction overlay.