### PR TITLE
PERA-4023 - [IOS] - Joint Account - BUG - Pending Signature bottom sheet not correct for SIGNERS

### DIFF
--- a/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
+++ b/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
@@ -144,15 +144,7 @@ extension SendTransactionFlowCoordinator {
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
         
         Task { @MainActor in
-            
-            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(
-                signRequestID: signRequestMetadata.signRequestID,
-                proposerAddress: signRequestMetadata.proposerAddress,
-                signaturesInfo: signRequestMetadata.signaturesInfo,
-                threshold: signRequestMetadata.threshold,
-                deadline: signRequestMetadata.deadline
-            )
-         
+            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: true)
             presentingScreen.present(viewController, animated: true)
         }
     }

--- a/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
+++ b/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
@@ -143,15 +143,18 @@ extension SendTransactionFlowCoordinator {
     
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
         
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(
-            signRequestID: signRequestMetadata.signRequestID,
-            proposerAddress: signRequestMetadata.proposerAddress,
-            signaturesInfo: signRequestMetadata.signaturesInfo,
-            threshold: signRequestMetadata.threshold,
-            deadline: signRequestMetadata.deadline
-        )
-        
-        presentingScreen.present(viewController, animated: true)
+        Task { @MainActor in
+            
+            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(
+                signRequestID: signRequestMetadata.signRequestID,
+                proposerAddress: signRequestMetadata.proposerAddress,
+                signaturesInfo: signRequestMetadata.signaturesInfo,
+                threshold: signRequestMetadata.threshold,
+                deadline: signRequestMetadata.deadline
+            )
+         
+            presentingScreen.present(viewController, animated: true)
+        }
     }
 }
 

--- a/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
+++ b/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
@@ -186,7 +186,7 @@ final class IncomingASAAccountsViewController: BaseViewController {
     }
     
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata)
+        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: false)
         present(viewController, animated: true)
     }
     

--- a/PeraWallet/Managers/Core/Services/Data Types/PeraAccount.swift
+++ b/PeraWallet/Managers/Core/Services/Data Types/PeraAccount.swift
@@ -51,6 +51,7 @@ extension PeraAccount {
 
 extension PeraAccount.AccountType {
     var isStandardAccount: Bool { self == .algo25 || self == .universalWallet }
+    var canAuthorize: Bool { self != .invalid || self != .watch }
 }
 
 extension PeraAccount.AccountType {

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlay.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlay.swift
@@ -99,7 +99,7 @@ struct JointAccountPendingTransactionOverlay: View {
     @ViewBuilder
     private func buttonsRow() -> some View {
         switch viewModel.transactionState {
-        case .inProgress:
+        case let .inProgress(canCancelTransaction) where canCancelTransaction:
             HStack(spacing: 20.0) {
                 RoundedButton(
                     contentType: viewModel.isCancelProcessStarted ? .spinner : .text("title-cancel"),
@@ -109,7 +109,7 @@ struct JointAccountPendingTransactionOverlay: View {
                 )
                 RoundedButton(contentType: .text("joint-account-pending-transaction-overlay-button-close"), style: .primary, isEnabled: true, onTap: onCloseAction)
             }
-        case .success, .cancelled, .failed:
+        case .success, .cancelled, .failed, .inProgress:
             RoundedButton(contentType: .text("title-close"), style: .secondary, isEnabled: true, onTap: onCloseAction)
         }
     }

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
@@ -19,7 +19,7 @@ import Foundation
 enum JointAccountPendingTransactionOverlayConstructor {
     
     @MainActor
-    static func buildScene(legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date) -> JointAccountPendingTransactionOverlay {
+    static func buildScene(legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date, isCancelTransactionAvailable: Bool) -> JointAccountPendingTransactionOverlay {
         let model = JointAccountPendingTransactionOverlayModel(
             accountsService: PeraCoreManager.shared.accounts,
             legacyBannerController: legacyBannerController,
@@ -27,34 +27,37 @@ enum JointAccountPendingTransactionOverlayConstructor {
             proposerAddress: proposerAddress,
             signaturesInfo: signaturesInfo,
             threshold: threshold,
-            deadline: deadline
+            deadline: deadline,
+            isCancelTransactionAvailable: isCancelTransactionAvailable
         )
         return JointAccountPendingTransactionOverlay(model: model)
     }
     
     @MainActor
-    static func buildViewController(signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo],
-                                    threshold: Int, deadline: Date, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
+    static func buildViewController(signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int,
+                                    deadline: Date, isCancelTransactionAvailable: Bool, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,
             signRequestID: signRequestID,
             proposerAddress: proposerAddress,
             signaturesInfo: signaturesInfo,
             threshold: threshold,
-            deadline: deadline
+            deadline: deadline,
+            isCancelTransactionAvailable: isCancelTransactionAvailable
         )
         return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
     }
     
     @MainActor
-    static func buildViewController(signRequestMetadata: SignRequestMetadata, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
+    static func buildViewController(signRequestMetadata: SignRequestMetadata, isCancelTransactionAvailable: Bool, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,
             signRequestID: signRequestMetadata.signRequestID,
             proposerAddress: signRequestMetadata.proposerAddress,
             signaturesInfo: signRequestMetadata.signaturesInfo,
             threshold: signRequestMetadata.threshold,
-            deadline: signRequestMetadata.deadline
+            deadline: signRequestMetadata.deadline,
+            isCancelTransactionAvailable: isCancelTransactionAvailable
         )
         return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
     }

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
@@ -18,6 +18,7 @@ import Foundation
 
 enum JointAccountPendingTransactionOverlayConstructor {
     
+    @MainActor
     static func buildScene(legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date) -> JointAccountPendingTransactionOverlay {
         let model = JointAccountPendingTransactionOverlayModel(
             accountsService: PeraCoreManager.shared.accounts,
@@ -31,6 +32,7 @@ enum JointAccountPendingTransactionOverlayConstructor {
         return JointAccountPendingTransactionOverlay(model: model)
     }
     
+    @MainActor
     static func buildViewController(signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo],
                                     threshold: Int, deadline: Date, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
@@ -44,6 +46,7 @@ enum JointAccountPendingTransactionOverlayConstructor {
         return JointAccountPendingTransactionOverlayViewController(rootView: view, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
     }
     
+    @MainActor
     static func buildViewController(signRequestMetadata: SignRequestMetadata, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayModel.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayModel.swift
@@ -75,7 +75,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
     private let pollingService = PollingService(timeInterval: .seconds(6))
     private let legacyBannerController: BannerController?
     private let proposerAddress: String
-    private let isProposer: Bool
+    private let isCancelTransactionAvailable: Bool
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Properties - JointAccountPendingTransactionOverlayViewModelable
@@ -85,23 +85,22 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
     // MARK: - Initialisers
     
     @MainActor
-    init(accountsService: AccountsServiceable, legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date) {
+    init(accountsService: AccountsServiceable, legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date, isCancelTransactionAvailable: Bool) {
         
         self.accountsService = accountsService
         self.legacyBannerController = legacyBannerController
         self.signRequestID = signRequestID
         self.proposerAddress = proposerAddress
+        self.isCancelTransactionAvailable = isCancelTransactionAvailable
         
         let participants = signaturesInfo.map(\.address)
         let localAccounts = accountsService.accounts.value.filter { participants.contains($0.address) }
-        
-        isProposer = localAccounts.contains { $0.address == proposerAddress && $0.type.canAuthorize }
         
         let accountsModels = signaturesInfo
             .sorted { $0.address < $1.address }
             .map { accountModel(address: $0.address, signRequestStatus: $0.status, localAccounts: localAccounts) }
         
-        viewModel.transactionState = .inProgress(canCancelTransaction: isProposer)
+        viewModel.transactionState = .inProgress(canCancelTransaction: isCancelTransactionAvailable)
         viewModel.threshold = threshold
         viewModel.deadline = deadline
         
@@ -204,7 +203,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
         if let status = result.status {
             switch status {
             case .pending, .ready, .submitting:
-                viewModel.transactionState = .inProgress(canCancelTransaction: isProposer)
+                viewModel.transactionState = .inProgress(canCancelTransaction: isCancelTransactionAvailable)
                 isTransactionInProgress = true
             case .confirmed:
                 viewModel.transactionState = .success

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayModel.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayModel.swift
@@ -38,7 +38,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
     }
     
     enum TransactionStatus {
-        case inProgress
+        case inProgress(canCancelTransaction: Bool)
         case success
         case cancelled
         case failed(errorMessage: String)
@@ -62,7 +62,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
         @Published fileprivate(set) var numberOfSignaturesText: String = ""
         @Published fileprivate(set) var deadline: Date = Date()
         @Published fileprivate(set) var threshold: Int = 0
-        @Published fileprivate(set) var transactionState: TransactionStatus = .inProgress
+        @Published fileprivate(set) var transactionState: TransactionStatus = .inProgress(canCancelTransaction: false)
         @Published fileprivate(set) var accounts: [AccountModel] = []
         @Published fileprivate(set) var isCancelProcessStarted: Bool = false
         @Published fileprivate(set) var error: ModelError?
@@ -75,6 +75,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
     private let pollingService = PollingService(timeInterval: .seconds(6))
     private let legacyBannerController: BannerController?
     private let proposerAddress: String
+    private let isProposer: Bool
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Properties - JointAccountPendingTransactionOverlayViewModelable
@@ -83,6 +84,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
     
     // MARK: - Initialisers
     
+    @MainActor
     init(accountsService: AccountsServiceable, legacyBannerController: BannerController?, signRequestID: String, proposerAddress: String, signaturesInfo: [SignRequestInfo], threshold: Int, deadline: Date) {
         
         self.accountsService = accountsService
@@ -93,18 +95,18 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
         let participants = signaturesInfo.map(\.address)
         let localAccounts = accountsService.accounts.value.filter { participants.contains($0.address) }
         
+        isProposer = localAccounts.contains { $0.address == proposerAddress && $0.type.canAuthorize }
+        
         let accountsModels = signaturesInfo
             .sorted { $0.address < $1.address }
             .map { accountModel(address: $0.address, signRequestStatus: $0.status, localAccounts: localAccounts) }
         
-        Task { @MainActor in
-            viewModel.threshold = threshold
-            viewModel.deadline = deadline
-            update(accounts: accountsModels)
-            
-            setupCallbacks()
-        }
+        viewModel.transactionState = .inProgress(canCancelTransaction: isProposer)
+        viewModel.threshold = threshold
+        viewModel.deadline = deadline
         
+        update(accounts: accountsModels)
+        setupCallbacks()
         startPoolingForData()
     }
     
@@ -202,7 +204,7 @@ final class JointAccountPendingTransactionOverlayModel: JointAccountPendingTrans
         if let status = result.status {
             switch status {
             case .pending, .ready, .submitting:
-                viewModel.transactionState = .inProgress
+                viewModel.transactionState = .inProgress(canCancelTransaction: isProposer)
                 isTransactionInProgress = true
             case .confirmed:
                 viewModel.transactionState = .success

--- a/PeraWallet/Scenes/Joint Account/Transaction Request/Summary/JointAccountTransactionRequestSummaryViewController.swift
+++ b/PeraWallet/Scenes/Joint Account/Transaction Request/Summary/JointAccountTransactionRequestSummaryViewController.swift
@@ -91,10 +91,7 @@ final class JointAccountTransactionRequestSummaryViewController: SwiftUICompatib
     }
     
     private func resolveProposerAddress(from jointAccount: Account) -> String? {
-        let participants = jointAccount.jointAccountParticipants ?? []
-        return participants
-            .compactMap { self.accountsService.account(address: $0)?.address }
-            .first
+        jointAccount.jointAccountParticipants?.first
     }
     
     private func fetchSignRequestMetadata(

--- a/PeraWallet/Scenes/Joint Account/Transaction Request/Summary/JointAccountTransactionRequestSummaryViewController.swift
+++ b/PeraWallet/Scenes/Joint Account/Transaction Request/Summary/JointAccountTransactionRequestSummaryViewController.swift
@@ -138,7 +138,7 @@ final class JointAccountTransactionRequestSummaryViewController: SwiftUICompatib
     }
     
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata)
+        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: false)
         present(viewController, animated: true)
     }
     

--- a/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
+++ b/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
@@ -72,7 +72,12 @@ final class JointAccountTransactionCoordinator {
         }
         
         Task { @MainActor in
-            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
+            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(
+                signRequestMetadata: signRequestMetadata,
+                isCancelTransactionAvailable: true,
+                onDismiss: onDismiss,
+                onCancelTransaction: onCancelTransaction
+            )
             presenter.present(viewController, animated: true)
         }
     }

--- a/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
+++ b/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
@@ -71,9 +71,8 @@ final class JointAccountTransactionCoordinator {
             self?.cancelAssetMonitoring(transactionType: transactionType, jointAccount: jointAccount, sharedDataController: sharedDataController)
         }
         
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
-        
         Task { @MainActor in
+            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, onDismiss: onDismiss, onCancelTransaction: onCancelTransaction)
             presenter.present(viewController, animated: true)
         }
     }


### PR DESCRIPTION
- Now, only signer can cancel shared account async transaction
- Fixed unreported issue with JointAccountPendingTransactionOverlay pop-up animation. Now capsules and buttons will animate properly when view appear on the screen.