### PR TITLE
[IOS] - Shared Account - Show Cancel + Close in pending sigs only when device holds proposer

### DIFF
--- a/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
+++ b/PeraWallet/Classes/Demo/QuickActions/SendTransactionFlowCoordinator.swift
@@ -144,7 +144,7 @@ extension SendTransactionFlowCoordinator {
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
         
         Task { @MainActor in
-            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: true, onJointAccountAnalyticsCall: nil)
+            let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: true)
             presentingScreen.present(viewController, animated: true)
         }
     }

--- a/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
+++ b/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
@@ -72,6 +72,7 @@ final class IncomingASAAccountsViewController: BaseViewController {
     private var positionYForVisibleAccountActionsMenuAction: CGFloat?
     private var cancellables = Set<AnyCancellable>()
     private var bottomSheetTransition: BottomSheetTransition?
+    private var pendingTransactionOverlay: JointAccountPendingTransactionOverlayViewController?
         
     init(model: InboxModelable, legacyConfiguration: ViewControllerConfiguration) {
         self.model = model
@@ -213,15 +214,26 @@ final class IncomingASAAccountsViewController: BaseViewController {
     private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata, jointAccount: Account, isCancelTransactionAvailable: Bool) {
         analytics.track(.jointAccount(type: .showPendingTransaction))
         
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: isCancelTransactionAvailable) { [weak self] in
-            self?.analytics.track(.jointAccount(type: .closePendingTransaction))
-        } onCancelTransaction: { [weak self] in
-            self?.analytics.track(.jointAccount(type: .cancelTransaction))
-            // TODO: add transactionType to finish the cancellation dialog
-//            openTransactionCancellationDialog(jointAccount: jointAccount, transactionType: <#T##JointAccountTransactionHandler.TransactionType#>, presenter: viewController, sharedDataController: self?.sharedDataController)
-        }
-
-        present(viewController, animated: true)
+        pendingTransactionOverlay = JointAccountPendingTransactionOverlayConstructor.buildViewController(
+            signRequestMetadata: signRequestMetadata,
+            isCancelTransactionAvailable: isCancelTransactionAvailable,
+            onDismiss: { [weak self] in
+                self?.analytics.track(.jointAccount(type: .closePendingTransaction))
+                self?.pendingTransactionOverlay = nil
+            },
+            onCancelTransaction: { [weak self] in
+                guard let self, let pendingTransactionOverlay else { return }
+                analytics.track(.jointAccount(type: .cancelTransaction))
+                openTransactionCancellationDialog(
+                    jointAccount: jointAccount,
+                    presenter: pendingTransactionOverlay,
+                    sharedDataController: sharedDataController
+                )
+            }
+        )
+        
+        guard let pendingTransactionOverlay else { return }
+        present(pendingTransactionOverlay, animated: true)
     }
     
     private func buildSignaturesInfo(
@@ -273,8 +285,7 @@ final class IncomingASAAccountsViewController: BaseViewController {
         )
     }
     
-    private func openTransactionCancellationDialog(jointAccount: Account, transactionType: JointAccountTransactionHandler.TransactionType,
-                                                   presenter: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
+    private func openTransactionCancellationDialog(jointAccount: Account, presenter: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
         
         let configurator = BottomWarningViewConfigurator(
             image: .iconIncomingAsaError,
@@ -282,16 +293,15 @@ final class IncomingASAAccountsViewController: BaseViewController {
             description: .plain(String(localized: "shared-account-cancel-transaction-confirmation-description")),
             primaryActionButtonTitle: String(localized: "shared-account-cancel-transaction-confirmation-primary-button-title"),
             secondaryActionButtonTitle: String(localized: "shared-account-cancel-transaction-confirmation-secondary-button-title"),
-            primaryAction: { [weak self] in self?.cancelTransaction(transactionType: transactionType, jointAccount: jointAccount, overlay: presenter, sharedDataController: sharedDataController) }
+            primaryAction: { [weak self] in self?.cancelTransaction(jointAccount: jointAccount, overlay: presenter, sharedDataController: sharedDataController) }
         )
         
         bottomSheetTransition = BottomSheetTransition(presentingViewController: presenter)
         bottomSheetTransition?.perform(.bottomWarning(configurator: configurator), by: .presentWithoutNavigationController)
     }
     
-    private func cancelTransaction(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, overlay: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
+    private func cancelTransaction(jointAccount: Account, overlay: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
         overlay.cancelTransaction()
-        cancelAssetMonitoring(transactionType: transactionType, jointAccount: jointAccount, sharedDataController: sharedDataController)
     }
     
     private func cancelAssetMonitoring(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, sharedDataController: SharedDataController) {

--- a/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
+++ b/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
@@ -304,22 +304,6 @@ final class IncomingASAAccountsViewController: BaseViewController {
         overlay.cancelTransaction()
     }
     
-    private func cancelAssetMonitoring(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, sharedDataController: SharedDataController) {
-        
-        let monitor = sharedDataController.blockchainUpdatesMonitor
-        
-        switch transactionType {
-        case let .optIn(draft):
-            guard let assetIndex = draft.assetIndex else { return }
-            monitor.cancelMonitoringOptInUpdates(forAssetID: assetIndex, for: jointAccount)
-        case let .optOut(draft):
-            guard let assetIndex = draft.assetIndex else { return }
-            monitor.markOptOutUpdatesForNotification(forAssetID: assetIndex, for: jointAccount)
-        case .rekey, .sendAlgos, .sendAsset:
-            break
-        }
-    }
-    
     // MARK: - Deinitializer
     
     deinit {

--- a/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
+++ b/PeraWallet/Classes/IncomingASA/Accounts/IncomingASAAccountsViewController.swift
@@ -71,6 +71,7 @@ final class IncomingASAAccountsViewController: BaseViewController {
     
     private var positionYForVisibleAccountActionsMenuAction: CGFloat?
     private var cancellables = Set<AnyCancellable>()
+    private var bottomSheetTransition: BottomSheetTransition?
         
     init(model: InboxModelable, legacyConfiguration: ViewControllerConfiguration) {
         self.model = model
@@ -119,8 +120,10 @@ final class IncomingASAAccountsViewController: BaseViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Int, InboxViewModel.RowType>()
         snapshot.appendSections([0])
         snapshot.appendItems(rows)
-        listDataSource.apply(snapshot)
-        noContentView.isHidden = !rows.isEmpty
+        DispatchQueue.main.async { [weak self] in
+            self?.listDataSource.apply(snapshot)
+            self?.noContentView.isHidden = !rows.isEmpty
+        }
     }
     
     private func handle(action: InboxViewModel.Action) {
@@ -184,7 +187,11 @@ final class IncomingASAAccountsViewController: BaseViewController {
     }
     
     private func presentSigningStatusOverlay(request: SignRequestObject) {
-        guard let responses = request.transactionLists.first?.responses, let proposerAddress = request.proposerAddress else { return }
+        guard
+            let responses = request.transactionLists.first?.responses,
+                let proposerAddress = request.proposerAddress,
+                let account = PeraCoreManager.shared.accounts.account(address: request.jointAccount.address)
+        else { return }
         do {
             let signaturesInfo = try buildSignaturesInfo(
                 from: request.jointAccount.participantAddresses,
@@ -197,20 +204,23 @@ final class IncomingASAAccountsViewController: BaseViewController {
                 threshold: request.jointAccount.threshold,
                 deadline: request.expectedExpireDatetime
             )
-            showJointAccountPendingTransactionOverlay(signRequestMetadata: signRequestMetadata)
+            showJointAccountPendingTransactionOverlay(signRequestMetadata: signRequestMetadata, jointAccount: account, isCancelTransactionAvailable: PeraCoreManager.shared.accounts.account(address: proposerAddress) != nil)
         } catch {
             show(error: error)
         }
     }
     
-    private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata) {
+    private func showJointAccountPendingTransactionOverlay(signRequestMetadata: SignRequestMetadata, jointAccount: Account, isCancelTransactionAvailable: Bool) {
         analytics.track(.jointAccount(type: .showPendingTransaction))
-        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: false) { [weak self] event in
-            switch event {
-            case .closePendingTransaction: self?.analytics.track(.jointAccount(type: .closePendingTransaction))
-            default: break
-            }
+        
+        let viewController = JointAccountPendingTransactionOverlayConstructor.buildViewController(signRequestMetadata: signRequestMetadata, isCancelTransactionAvailable: isCancelTransactionAvailable) { [weak self] in
+            self?.analytics.track(.jointAccount(type: .closePendingTransaction))
+        } onCancelTransaction: { [weak self] in
+            self?.analytics.track(.jointAccount(type: .cancelTransaction))
+            // TODO: add transactionType to finish the cancellation dialog
+//            openTransactionCancellationDialog(jointAccount: jointAccount, transactionType: <#T##JointAccountTransactionHandler.TransactionType#>, presenter: viewController, sharedDataController: self?.sharedDataController)
         }
+
         present(viewController, animated: true)
     }
     
@@ -261,6 +271,43 @@ final class IncomingASAAccountsViewController: BaseViewController {
             ),
             by: .push
         )
+    }
+    
+    private func openTransactionCancellationDialog(jointAccount: Account, transactionType: JointAccountTransactionHandler.TransactionType,
+                                                   presenter: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
+        
+        let configurator = BottomWarningViewConfigurator(
+            image: .iconIncomingAsaError,
+            title: String(localized: "shared-account-cancel-transaction-confirmation-title"),
+            description: .plain(String(localized: "shared-account-cancel-transaction-confirmation-description")),
+            primaryActionButtonTitle: String(localized: "shared-account-cancel-transaction-confirmation-primary-button-title"),
+            secondaryActionButtonTitle: String(localized: "shared-account-cancel-transaction-confirmation-secondary-button-title"),
+            primaryAction: { [weak self] in self?.cancelTransaction(transactionType: transactionType, jointAccount: jointAccount, overlay: presenter, sharedDataController: sharedDataController) }
+        )
+        
+        bottomSheetTransition = BottomSheetTransition(presentingViewController: presenter)
+        bottomSheetTransition?.perform(.bottomWarning(configurator: configurator), by: .presentWithoutNavigationController)
+    }
+    
+    private func cancelTransaction(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, overlay: JointAccountPendingTransactionOverlayViewController, sharedDataController: SharedDataController) {
+        overlay.cancelTransaction()
+        cancelAssetMonitoring(transactionType: transactionType, jointAccount: jointAccount, sharedDataController: sharedDataController)
+    }
+    
+    private func cancelAssetMonitoring(transactionType: JointAccountTransactionHandler.TransactionType, jointAccount: Account, sharedDataController: SharedDataController) {
+        
+        let monitor = sharedDataController.blockchainUpdatesMonitor
+        
+        switch transactionType {
+        case let .optIn(draft):
+            guard let assetIndex = draft.assetIndex else { return }
+            monitor.cancelMonitoringOptInUpdates(forAssetID: assetIndex, for: jointAccount)
+        case let .optOut(draft):
+            guard let assetIndex = draft.assetIndex else { return }
+            monitor.markOptOutUpdatesForNotification(forAssetID: assetIndex, for: jointAccount)
+        case .rekey, .sendAlgos, .sendAsset:
+            break
+        }
     }
     
     // MARK: - Deinitializer

--- a/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
+++ b/PeraWallet/Scenes/Joint Account/Pending Transaction Overlay/JointAccountPendingTransactionOverlayConstructor.swift
@@ -49,7 +49,7 @@ enum JointAccountPendingTransactionOverlayConstructor {
     }
     
     @MainActor
-    static func buildViewController(signRequestMetadata: SignRequestMetadata, isCancelTransactionAvailable: Bool, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil, onJointAccountAnalyticsCall: ((JointAccountAnalyticEvent) -> Void)?) -> JointAccountPendingTransactionOverlayViewController {
+    static func buildViewController(signRequestMetadata: SignRequestMetadata, isCancelTransactionAvailable: Bool, onDismiss: (() -> Void)? = nil, onCancelTransaction: (() -> Void)? = nil, onJointAccountAnalyticsCall: ((JointAccountAnalyticEvent) -> Void)? = nil) -> JointAccountPendingTransactionOverlayViewController {
         let view = buildScene(
             legacyBannerController: AppDelegate.shared?.appConfiguration.bannerController,
             signRequestID: signRequestMetadata.signRequestID,

--- a/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
+++ b/PeraWallet/Utils/Handlers/JointAccountTransactionCoordinator.swift
@@ -80,8 +80,7 @@ final class JointAccountTransactionCoordinator {
                 signRequestMetadata: signRequestMetadata,
                 isCancelTransactionAvailable: true,
                 onDismiss: onDismiss,
-                onCancelTransaction: onCancelTransaction,
-                onJointAccountAnalyticsCall: nil
+                onCancelTransaction: onCancelTransaction
             )
             confirmationDialogPresenter = viewController
             presenter.present(viewController, animated: true)


### PR DESCRIPTION
show cancel button when accessing the pending signatures overlay from the inbox