### PR TITLE
PERA-4154 - [IOS] - Shared Account - Signing rekeyed transactions with Ledger not functional

### DIFF
--- a/PeraWallet/Utils/Handlers/JointAccountTransactionHandler.swift
+++ b/PeraWallet/Utils/Handlers/JointAccountTransactionHandler.swift
@@ -50,7 +50,10 @@ final class JointAccountTransactionHandler {
     
     @MainActor
     func isConnectionWithLedgerRequired(jointAccount: Account) -> Bool {
-        guard let participants = jointAccount.jointAccountParticipants else { return false }
+        
+        let signerAccount = accountsService.account(address: jointAccount.signerAddress)
+        
+        guard let participants = signerAccount?.jointAccountParticipants else { return false }
         return participants
             .compactMap { accountsService.account(address: $0) }
             .contains { $0.hasLedgerDetail() }


### PR DESCRIPTION
- Fixed reported issue. Now, the joint account signing flow will use correct accounts when joint account is rekeyed.