### PR TITLE
[PERA-4113] - BUG - Deeplink not functional 

### DIFF
--- a/PeraWalletCore/Models/Contacts/QR/QRText.swift
+++ b/PeraWalletCore/Models/Contacts/QR/QRText.swift
@@ -118,6 +118,8 @@ public final class QRText: Codable {
                   amount != nil {
             if amount == 0 && address == nil {
                 mode = .optInRequest
+            } else if asset == 0 {
+                mode = .algosRequest
             } else {
                 mode = .assetRequest
             }
@@ -289,6 +291,8 @@ public final class QRText: Codable {
 
             return nil
         }
+
+        let address = address ?? queryParameters[QRText.CodingKeys.address.rawValue]
         
         if let type = queryParameters[QRText.CodingKeys.type.rawValue],
            type == "keyreg" {
@@ -355,6 +359,20 @@ public final class QRText: Codable {
 
         if let amount = queryParameters[QRText.CodingKeys.amount.rawValue],
            let asset = queryParameters[QRText.CodingKeys.asset.rawValue] {
+
+            if Int64(asset) == 0 {
+                guard let address = address else {
+                    return nil
+                }
+
+                return Self(
+                    mode: .algosRequest,
+                    address: address,
+                    amount: UInt64(amount),
+                    note: queryParameters[QRText.CodingKeys.note.rawValue],
+                    lockedNote: queryParameters[QRText.CodingKeys.lockedNote.rawValue]
+                )
+            }
 
             if let address = address {
                 return Self(

--- a/algorand-tests/Models/QR/QRTextTests.swift
+++ b/algorand-tests/Models/QR/QRTextTests.swift
@@ -268,4 +268,52 @@ class QRTextTests: XCTestCase {
             XCTAssertNotNil(decoded)
         }
     }
+    
+    func testQRTextBuildWithAddressQueryParameter() {
+        // Legacy deeplinks may carry the receiver as a query param instead of the URL host,
+        // e.g. perawallet://?address=...&amount=...&asset=0
+        let params = [
+            "address": "GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ",
+            "amount": "20000000",
+            "asset": "0",
+            "xnote": "b_59596073_1051287026_0"
+        ]
+        let qr = QRText.build(for: nil, with: params)
+
+        XCTAssertNotNil(qr)
+        XCTAssertEqual(qr?.mode, .algosRequest)
+        XCTAssertEqual(qr?.address, "GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ")
+        XCTAssertEqual(qr?.amount, 20000000)
+        XCTAssertEqual(qr?.lockedNote, "b_59596073_1051287026_0")
+    }
+
+    func testQRTextBuildWithAssetZeroIsAlgosRequest() {
+        // asset=0 means ALGO, not an ASA
+        let params = ["amount": "500", "asset": "0", "note": "payment"]
+        let qr = QRText.build(for: "ABC123", with: params)
+
+        XCTAssertNotNil(qr)
+        XCTAssertEqual(qr?.mode, .algosRequest)
+        XCTAssertEqual(qr?.address, "ABC123")
+        XCTAssertEqual(qr?.amount, 500)
+        XCTAssertEqual(qr?.note, "payment")
+        XCTAssertNil(qr?.asset)
+    }
+
+    func testQRTextBuildWithAssetZeroAndNoAddressReturnsNil() {
+        let params = ["amount": "500", "asset": "0"]
+        XCTAssertNil(QRText.build(for: nil, with: params))
+    }
+
+    func testQRModeDecodingWithAssetZeroIsAlgosRequest() {
+        // JSON-format QR with asset 0 must decode as an ALGO request
+        let json = """
+        {"version":"1.0","address":"ABC123","amount":"500","asset":"0"}
+        """
+        let decoded = try! JSONDecoder().decode(QRText.self, from: json.data(using: .utf8)!)
+
+        XCTAssertEqual(decoded.mode, .algosRequest)
+        XCTAssertEqual(decoded.address, "ABC123")
+        XCTAssertEqual(decoded.amount, 500)
+    }
 }

--- a/algorand-tests/Utils/Deeplinks/Routing/DeeplinkQRTests.swift
+++ b/algorand-tests/Utils/Deeplinks/Routing/DeeplinkQRTests.swift
@@ -205,4 +205,28 @@ final class DeeplinkQRTests: XCTestCase {
         XCTAssertEqual(accountDetailQR?.mode, .accountDetail)
         XCTAssertEqual(accountDetailQR?.address, "ACCOUNT123")
     }
+    
+    func testLegacyDeeplinkWithAddressQueryParamAndAssetZero() {
+        // perawallet://?address=...&amount=...&asset=0&xnote=... — the format produced by
+        // payment-request redirect pages; address is a query param, asset 0 means ALGO
+        let url = URL(string: "perawallet://?address=GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ&amount=20000000&asset=0&xnote=b_59596073_1051287026_0")!
+        let qr = DeeplinkQR(url: url).qrText()
+
+        XCTAssertNotNil(qr)
+        XCTAssertEqual(qr?.mode, .algosRequest)
+        XCTAssertEqual(qr?.address, "GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ")
+        XCTAssertEqual(qr?.amount, 20000000)
+        XCTAssertEqual(qr?.lockedNote, "b_59596073_1051287026_0")
+    }
+
+    func testLegacyDeeplinkWithHostAddressAndAssetZero() {
+        // Host-based legacy form: algorand://ADDRESS?amount=...&asset=0
+        let url = URL(string: "algorand://GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ?amount=20000000&asset=0")!
+        let qr = DeeplinkQR(url: url).qrText()
+
+        XCTAssertNotNil(qr)
+        XCTAssertEqual(qr?.mode, .algosRequest)
+        XCTAssertEqual(qr?.address, "GTAKGY64LESRSFFNYFAXJTACK5WSCOSNWTY62KVR2H76SHOYN5AJYAADGQ")
+        XCTAssertEqual(qr?.amount, 20000000)
+    }
 }


### PR DESCRIPTION
- Fix legacy payment deeplinks: parse address from query params and route asset=0 to the ALGO transfer flow instead of an empty asset account list
- Tests added

